### PR TITLE
feat: game history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main # or your default branch
 
+  workflow_dispatch:
+
 permissions:
   contents: write # required for GH Pages deployment
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 import GamePage from "./pages/GamePage";
 import HomePage from "./pages/HomePage";
+import ReplayPage from "./pages/ReplayPage";
 import { SnackbarProvider } from "notistack";
 import CssBaseline from "@mui/material/CssBaseline";
 
@@ -11,6 +12,7 @@ const App = () => {
 			<Routes>
 				<Route path="/" element={<HomePage />} />
 				<Route path="/game/:id" element={<GamePage />} />
+				<Route path="/replay/:id" element={<ReplayPage />} />
 				<Route path="*" element={<Navigate to="/" />} />
 			</Routes>
 		</SnackbarProvider>

--- a/src/api/gameApi.ts
+++ b/src/api/gameApi.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { GameState, PlayerCreate } from "../types/game";
+import { GameState, PlayerCreate, PlayerInfo } from "../types/game";
 
 const API = axios.create({
 	baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -7,6 +7,16 @@ const API = axios.create({
 
 export const getAllGames = async (): Promise<GameState[]> => {
 	const res = await API.get("/games");
+	return res.data;
+};
+
+export const getPlayer = async (playerId: string): Promise<PlayerInfo> => {
+	const res = await API.get(`/players/${playerId}`);
+	return res.data;
+};
+
+export const getGamesByPlayer = async (playerId: string): Promise<GameState[]> => {
+	const res = await API.get(`/players/${playerId}/games`);
 	return res.data;
 };
 

--- a/src/api/gameApi.ts
+++ b/src/api/gameApi.ts
@@ -51,3 +51,8 @@ export const makeBotMove = async (gameId: string, difficulty: string): Promise<G
 	const res = await API.post(`/games/${gameId}/bot_move/${difficulty}`);
 	return res.data;
 };
+
+export const getReplay = async (gameId: string): Promise<string[][][]> => {
+	const res = await API.get(`/games/${gameId}/replay`);
+	return res.data;
+};

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -168,12 +168,14 @@ const GamePage = () => {
 
 	const mySymbol = getPlayerSymbol();
 	const isMyTurn = mySymbol === game.current_turn;
-	const canMove = game.status === "in_progress" && isMyTurn;
+
+	const isOldGame = game.status !== "in_progress";
+	const canMove = !isOldGame && isMyTurn;
 	const isOnlineGame = game.player_1.type === "human" && game.player_2.type === "human" && game.player_1.id !== game.player_2.id;
 
 	const isGameOver = game.status !== "in_progress";
 
-	const winnerName = game.status === "x_won" ? game.player_1.nickname : game.status === "o_won" ? game.player_2.nickname : null;
+	// const winnerName = game.status === "x_won" ? game.player_1.nickname : game.status === "o_won" ? game.player_2.nickname : null;
 	const opponentNickname = mySymbol === "x" ? game.player_2.nickname : game.player_1.nickname;
 
 	const localPlayerNickname = mySymbol === "x" ? game.player_1.nickname : game.player_2.nickname;
@@ -324,10 +326,12 @@ const GamePage = () => {
 
 				{isGameOver && (
 					<Typography variant="h5" sx={{ mt: 2, fontWeight: "bold" }} color="primary">
-						{winnerName ? `${winnerName} wins! 🎉` : "It's a draw!"}
+						{game.status === "x_won" && `${game.player_1.nickname} wins! 🎉`}
+						{game.status === "o_won" && `${game.player_2.nickname} wins! 🎉`}
+						{game.status === "draw" && "It's a draw!"}
+						{game.status === "abandoned" && "Game was abandoned."}
 					</Typography>
 				)}
-
 				<Button onClick={handleBack} variant="contained" sx={{ mt: 4 }}>
 					Back
 				</Button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -239,6 +239,9 @@ const HomePage = () => {
 									<Button variant="outlined" onClick={() => navigate(`/game/${game.id}`, { state: { playerId } })}>
 										View
 									</Button>
+									<Button variant="outlined" onClick={() => navigate(`/replay/${game.id}`, { state: { playerId, replay: true } })}>
+										Replay
+									</Button>
 								</Box>
 							))}
 						</Box>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,8 +14,9 @@ import {
 	DialogActions,
 } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { createGame, createPlayer } from "../api/gameApi";
-import { PlayerCreate, PlayerType } from "../types/game";
+import { createGame, createPlayer, getGamesByPlayer, getPlayer } from "../api/gameApi";
+import { PlayerCreate, PlayerType, GameState } from "../types/game";
+import { useEffect } from "react";
 
 const playerOptions = [
 	{ label: "Me", value: "me" },
@@ -31,50 +32,109 @@ const HomePage = () => {
 	const navigate = useNavigate();
 	const [onlineModalOpen, setOnlineModalOpen] = useState(false);
 	const [waitingSocket, setWaitingSocket] = useState<WebSocket | null>(null);
+	const [playerId, setPlayerId] = useState<string | null>(localStorage.getItem("playerId"));
+	const [gameHistory, setGameHistory] = useState<GameState[]>([]);
+
+	// Load existing player
+	useEffect(() => {
+		const storedId = localStorage.getItem("playerId");
+		if (storedId) {
+			getPlayer(storedId).then((player) => {
+				setNickname(player.nickname);
+				setPlayerId(storedId);
+				loadGameHistory(storedId);
+			});
+		}
+	}, []);
+
+	const loadGameHistory = async (id: string) => {
+		const history = await getGamesByPlayer(id);
+		setGameHistory(history.reverse()); // show newest first
+	};
 
 	const handleStartGame = async () => {
-		const player1: PlayerCreate = {
-			nickname: player1Type === "me" ? nickname : "Player 1",
-			type: player1Type === "me" ? "human" : (player1Type as PlayerType),
-		};
+		let localPlayerId = localStorage.getItem("playerId");
+		let p1Id: string;
 
-		const player2: PlayerCreate = {
+		if (player1Type === "me" && localPlayerId) {
+			// Player already exists locally, fetch from DB to get nickname
+			try {
+				const existingPlayer = await getPlayer(localPlayerId);
+				setNickname(existingPlayer.nickname);
+				p1Id = existingPlayer.id;
+			} catch {
+				// If somehow invalid, create fresh
+				const newPlayer: PlayerCreate = { nickname, type: "human" };
+				p1Id = await createPlayer(newPlayer);
+				localStorage.setItem("playerId", p1Id);
+				localStorage.setItem("nickname", newPlayer.nickname);
+				setPlayerId(p1Id);
+			}
+		} else if (player1Type === "me") {
+			// No player stored, create new
+			const newPlayer: PlayerCreate = { nickname, type: "human" };
+			p1Id = await createPlayer(newPlayer);
+			localStorage.setItem("playerId", p1Id);
+			localStorage.setItem("nickname", newPlayer.nickname);
+			setPlayerId(p1Id);
+		} else {
+			// Bot case
+			const botPlayer: PlayerCreate = { nickname: "Player 1", type: player1Type as PlayerType };
+			p1Id = await createPlayer(botPlayer);
+		}
+
+		const p2: PlayerCreate = {
 			nickname: player2Type === "me" ? nickname : "Player 2",
 			type: player2Type === "me" ? "human" : (player2Type as PlayerType),
 		};
 
-		const p1Id = await createPlayer(player1);
-		const p2Id = await createPlayer(player2);
-
+		const p2Id = await createPlayer(p2);
 		const newGame = await createGame(p1Id, p2Id);
-		if (newGame) navigate(`/game/${newGame.id}`, { state: { playerId: p1Id } });
+
+		await loadGameHistory(p1Id);
+		navigate(`/game/${newGame.id}`, { state: { playerId: p1Id } });
 	};
 
 	const handleOnlineGame = async () => {
-		const newPlayer: PlayerCreate = {
-			nickname,
-			type: "human",
-		};
+		let localPlayerId = localStorage.getItem("playerId");
 
-		const playerId = await createPlayer(newPlayer);
+		if (localPlayerId) {
+			try {
+				const existing = await getPlayer(localPlayerId);
+				setNickname(existing.nickname);
+				setPlayerId(existing.id);
+			} catch {
+				localPlayerId = null;
+			}
+		}
+
+		if (!localPlayerId) {
+			const newPlayer: PlayerCreate = { nickname, type: "human" };
+			localPlayerId = await createPlayer(newPlayer);
+			localStorage.setItem("playerId", localPlayerId);
+			localStorage.setItem("nickname", newPlayer.nickname);
+			setPlayerId(localPlayerId);
+		}
 
 		const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/online-game`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ player_id: playerId }),
+			body: JSON.stringify({ player_id: localPlayerId }),
 		});
 
 		const data = await res.json();
 
+		await loadGameHistory(localPlayerId);
+
 		if (data.waiting) {
 			setOnlineModalOpen(true);
 
-			const socket = new WebSocket(`${import.meta.env.VITE_WS_BASE_URL}/waiting/${playerId}`);
+			const socket = new WebSocket(`${import.meta.env.VITE_WS_BASE_URL}/waiting/${localPlayerId}`);
 			socket.onmessage = (event) => {
 				const game = JSON.parse(event.data);
 				socket.close();
 				setOnlineModalOpen(false);
-				navigate(`/game/${game.id}`, { state: { playerId } });
+				navigate(`/game/${game.id}`, { state: { playerId: localPlayerId } });
 			};
 
 			socket.onerror = () => {
@@ -83,7 +143,7 @@ const HomePage = () => {
 
 			setWaitingSocket(socket);
 		} else {
-			navigate(`/game/${data.game.id}`, { state: { playerId } });
+			navigate(`/game/${data.game.id}`, { state: { playerId: localPlayerId } });
 		}
 	};
 
@@ -153,6 +213,36 @@ const HomePage = () => {
 					<Button variant="contained" color="success" onClick={handleOnlineGame}>
 						Online Game
 					</Button>
+
+					{gameHistory.length > 0 && (
+						<Box width="100%" mt={4}>
+							<Typography variant="h5" gutterBottom>
+								Game History
+							</Typography>
+							{gameHistory.map((game) => (
+								<Box
+									key={game.id}
+									display="flex"
+									justifyContent="space-between"
+									alignItems="center"
+									mb={1}
+									sx={{ padding: 1, border: "1px solid #ccc", borderRadius: 2 }}
+								>
+									<Box>
+										<Typography variant="body1">
+											{game.player_1.nickname} (x) vs {game.player_2.nickname} (o)
+										</Typography>
+										<Typography variant="body2" color="text.secondary">
+											Status: {game.status}
+										</Typography>
+									</Box>
+									<Button variant="outlined" onClick={() => navigate(`/game/${game.id}`, { state: { playerId } })}>
+										View
+									</Button>
+								</Box>
+							))}
+						</Box>
+					)}
 				</Box>
 			</Box>
 			<Dialog open={onlineModalOpen}>

--- a/src/pages/ReplayPage.tsx
+++ b/src/pages/ReplayPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getGame } from "../api/gameApi";
+import { GameState } from "../types/game";
+import { Box, Typography, Button, CircularProgress } from "@mui/material";
+
+const ReplayPage = () => {
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const [game, setGame] = useState<GameState | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchAndReplay = async () => {
+			if (!id) return;
+			setLoading(true);
+			try {
+				const data = await getGame(id);
+				setGame(data);
+
+				await delay(1000);
+				await playReplay(data.moves);
+			} finally {
+				setLoading(false);
+			}
+		};
+		fetchAndReplay();
+	}, [id]);
+
+	const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+	const playReplay = async (moves: { player: string; row: number; side: "L" | "R" }[]) => {
+		for (let move of moves) {
+			await delay(1000);
+			setGame((prev) => {
+				if (!prev) return prev;
+				const updatedBoard = JSON.parse(JSON.stringify(prev.board));
+				applyMoveLocally(updatedBoard, move.row, move.side, move.player);
+				const nextTurn = move.player === "x" ? "o" : "x";
+				return { ...prev, board: updatedBoard, current_turn: nextTurn };
+			});
+		}
+	};
+
+	const applyMoveLocally = (board: string[][], row: number, side: "L" | "R", symbol: string) => {
+		if (side === "L") {
+			for (let col = 0; col < board[0].length; col++) {
+				if (board[row][col] === "_") {
+					for (let shift = col; shift > 0; shift--) {
+						board[row][shift] = board[row][shift - 1];
+					}
+					board[row][0] = symbol;
+					break;
+				}
+			}
+		} else {
+			for (let col = board[0].length - 1; col >= 0; col--) {
+				if (board[row][col] === "_") {
+					for (let shift = col; shift < board[0].length - 1; shift++) {
+						board[row][shift] = board[row][shift + 1];
+					}
+					board[row][board[0].length - 1] = symbol;
+					break;
+				}
+			}
+		}
+	};
+
+	if (loading || !game) {
+		return (
+			<Box display="flex" justifyContent="center" alignItems="center" height="100vh">
+				<CircularProgress />
+			</Box>
+		);
+	}
+
+	return (
+		<Box
+			sx={{
+				height: "100vh",
+				width: "100vw",
+				display: "flex",
+				justifyContent: "center",
+				alignItems: "center",
+				backgroundColor: "#f5f5f5",
+				boxSizing: "border-box",
+				padding: 2,
+				overflowY: "auto",
+			}}
+		>
+			<Box
+				sx={{
+					maxWidth: 700,
+					width: "100%",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+				}}
+			>
+				{/* Board rendering, player names, etc (copy from GamePage but no move buttons) */}
+
+				<Typography variant="h4" sx={{ my: 2 }}>
+					Replay: {game.player_1.nickname} vs {game.player_2.nickname}
+				</Typography>
+
+				<Box>
+					{game.board.map((row, rowIndex) => (
+						<Box key={rowIndex} display="flex" alignItems="center" mb={1}>
+							{row.map((cell, colIndex) => (
+								<Box
+									key={colIndex}
+									sx={{
+										width: 40,
+										height: 40,
+										border: "1px solid #ccc",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										fontSize: 20,
+										fontWeight: "bold",
+										backgroundColor: cell === "x" ? "#2196f3" : cell === "o" ? "#f44336" : "#fff",
+										color: cell !== "_" ? "#fff" : "#000",
+									}}
+								>
+									{cell !== "_" ? cell : ""}
+								</Box>
+							))}
+						</Box>
+					))}
+				</Box>
+
+				<Button variant="contained" sx={{ mt: 4 }} onClick={() => navigate("/")}>
+					Return Home
+				</Button>
+			</Box>
+		</Box>
+	);
+};
+
+export default ReplayPage;

--- a/src/pages/ReplayPage.tsx
+++ b/src/pages/ReplayPage.tsx
@@ -16,7 +16,13 @@ const ReplayPage = () => {
 			setLoading(true);
 			try {
 				const data = await getGame(id);
-				setGame(data);
+
+				const emptyBoard = Array.from({ length: data.board.length }, () => Array.from({ length: data.board[0].length }, () => "_"));
+
+				setGame({
+					...data,
+					board: emptyBoard,
+				});
 
 				await delay(1000);
 				await playReplay(data.moves);
@@ -24,6 +30,7 @@ const ReplayPage = () => {
 				setLoading(false);
 			}
 		};
+
 		fetchAndReplay();
 	}, [id]);
 

--- a/src/pages/ReplayPage.tsx
+++ b/src/pages/ReplayPage.tsx
@@ -6,10 +6,10 @@ import { Box, Typography, Button, CircularProgress } from "@mui/material";
 
 const ReplayPage = () => {
 	const { id } = useParams<{ id: string }>();
-	const navigate = useNavigate();
 	const [game, setGame] = useState<GameState | null>(null);
+	const [board, setBoard] = useState<string[][]>([]);
 	const [loading, setLoading] = useState(true);
-
+	const navigate = useNavigate();
 	useEffect(() => {
 		const fetchAndReplay = async () => {
 			if (!id) return;
@@ -19,10 +19,8 @@ const ReplayPage = () => {
 
 				const emptyBoard = Array.from({ length: data.board.length }, () => Array.from({ length: data.board[0].length }, () => "_"));
 
-				setGame({
-					...data,
-					board: emptyBoard,
-				});
+				setGame(data);
+				setBoard(emptyBoard);
 
 				await delay(1000);
 				await playReplay(data.moves);
@@ -39,12 +37,10 @@ const ReplayPage = () => {
 	const playReplay = async (moves: { player: string; row: number; side: "L" | "R" }[]) => {
 		for (let move of moves) {
 			await delay(1000);
-			setGame((prev) => {
-				if (!prev) return prev;
-				const updatedBoard = JSON.parse(JSON.stringify(prev.board));
-				applyMoveLocally(updatedBoard, move.row, move.side, move.player);
-				const nextTurn = move.player === "x" ? "o" : "x";
-				return { ...prev, board: updatedBoard, current_turn: nextTurn };
+			setBoard((prevBoard) => {
+				const updated = JSON.parse(JSON.stringify(prevBoard));
+				applyMoveLocally(updated, move.row, move.side, move.player);
+				return updated;
 			});
 		}
 	};
@@ -111,7 +107,7 @@ const ReplayPage = () => {
 				</Typography>
 
 				<Box>
-					{game.board.map((row, rowIndex) => (
+					{board.map((row, rowIndex) => (
 						<Box key={rowIndex} display="flex" alignItems="center" mb={1}>
 							{row.map((cell, colIndex) => (
 								<Box

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -16,4 +16,5 @@ export interface GameState {
 	status: string;
 	player_1: PlayerInfo;
 	player_2: PlayerInfo;
+	moves: { player: string; row: number; side: "L" | "R" }[];
 }


### PR DESCRIPTION

# Pull Request: Implement Game History and Game Replay Features 

In this PR, I've implemented two major features:

## Interview 1: Game History

- **Player Persistence**:
  - On initial visit, a new player is created, and their `playerId` is stored in `localStorage`.
  - On returning visits, the app fetches the player's nickname from the backend to maintain consistency.
- **Nickname Prefill**:
  - Home page pre-fills the nickname input based on the stored player profile.
- **Game History UI**:
  - Displays a list of previous games for the logged-in player, ordered with the most recent games first.
  - Each game entry shows player names and the final game status.
  - Players can click **"View"** to inspect the final board state.
- **Access Control**:
  - Players can only view their **own** games. Games played by other players are not accessible.
- **Game Status Handling**:
  - Improved handling of game status (win, draw, abandoned) across the frontend.
  - Abandoned games are properly marked as non-interactive.

## Interview 2: Game Replay

- **Replay Mode**:
  - Players can click **"Replay"** to watch a full animation of their previous games.
- **Backend Support**:
  - A new API endpoint `/api/games/{game_id}/replay` was implemented.
  - Replay frames are generated server-side based on the original sequence of moves.
- **Frontend Replay Page**:
  - Added a dedicated `ReplayPage.tsx`.
  - Replays automatically step through each move, starting from an empty board and animating moves in real-time.
  - No user interaction is needed during replays.
- **Consistency**:
  - Replay logic is handled cleanly in the backend to ensure correctness.
  - The frontend is only responsible for displaying the frames sequentially.

